### PR TITLE
new fields for eviction data upload

### DIFF
--- a/src/nycdb/dataset_transformations.py
+++ b/src/nycdb/dataset_transformations.py
@@ -51,3 +51,6 @@ def acris(dataset, schema):
         return skip_fields(_to_csv, [s.lower() for s in schema['skip']])
     else:
         return _to_csv
+
+def evictions(dataset):
+    return to_csv(dataset.files[0].dest)

--- a/src/nycdb/datasets.yml
+++ b/src/nycdb/datasets.yml
@@ -191,7 +191,7 @@ pluto_16v2:
       Version: text
       lng: numeric
       lat: numeric
-      
+
 dobjobs:
   files:
     -
@@ -290,7 +290,7 @@ dobjobs:
         bbl: char(10)
         id: 'serial PRIMARY KEY'
 
-      
+
 hpd_complaints:
   files:
     -
@@ -343,7 +343,7 @@ dob_complaints:
 
 hpd_violations:
   files:
-    - 
+    -
       url: https://data.cityofnewyork.us/api/views/wvxf-dwi5/rows.csv?accessType=DOWNLOAD
       dest: hpd_violations.csv
   sql:
@@ -359,7 +359,7 @@ hpd_violations:
       HouseNumber: text
       LowHouseNumber: text
       HighHouseNumber: text
-      StreetName: text 
+      StreetName: text
       StreetCode: text
       Postcode: char(5)
       Apartment: text
@@ -368,14 +368,14 @@ hpd_violations:
       Lot: integer
       Class: char(1)
       InspectionDate: date
-      ApprovedDate: date 
+      ApprovedDate: date
       OriginalCertifyByDate: date
       OriginalCorrectByDate: date
       NewCertifyByDate: date
       NewCorrectByDate: date
       CertifiedDate: date
       OrderNumber: text
-      NOVID: integer 
+      NOVID: integer
       NOVDescription: text
       NOVIssuedDate: date
       CurrentStatusID: smallint
@@ -413,7 +413,7 @@ hpd_registrations:
     - hpd_registrations/registrations_grouped_by_bbl_with_contacts.sql
     - hpd_registrations/functions.sql
     - hpd_registrations/index.sql
-    
+
   schema:
     -
       table_name: hpd_registrations
@@ -780,4 +780,26 @@ acris:
           UCCCOLLATERALCODE: char(1)
           DESCRIPTION: text
 
-
+evictions:
+  files:
+    -
+      url: https://s3.amazonaws.com/justfix-data/evictions_geocoded.csv
+      dest: evictions_geocoded.csv
+  schema:
+    table_name: evictions
+    fields:
+      bin: integer
+      bbl: text
+      boro: text
+      address: text
+      zip: text
+      neighborhood: text
+      corpowner: text
+      corpownerpropublica: text
+      headofficer: text
+      evictions: integer
+      subsidy421a: boolean
+      subsidy421g: boolean
+      subsidyJ51: boolean
+      lat: numeric
+      lng: numeric

--- a/src/nycdb/verify.py
+++ b/src/nycdb/verify.py
@@ -31,6 +31,7 @@ TABLES = {
         'acris_property_type_codes': 46,
         'acris_ucc_collateral_codes': 8
     }
+    'evictions': {'evictions': 37000}
 }
 
 


### PR DESCRIPTION
This adds eviction filing data from January 2013 - June 2015 to nyc-db.

See this ProPublic article for more info on the data and where it came from: https://projects.propublica.org/evictions/#11/40.7900/-73.9600