### PR TITLE
Adding rentstab-summary dataset to nyc-db

### DIFF
--- a/src/nycdb/dataset_transformations.py
+++ b/src/nycdb/dataset_transformations.py
@@ -56,6 +56,8 @@ def dobjobs(dataset):
 def rentstab(dataset):
     return to_csv(dataset.files[0].dest)
 
+def rentstab_summary(dataset):
+    return to_csv(dataset.files[0].dest)
 
 def acris(dataset, schema):
     dest_file = next(filter(lambda f: schema['table_name'] in f.dest, dataset.files))

--- a/src/nycdb/datasets.yml
+++ b/src/nycdb/datasets.yml
@@ -572,6 +572,7 @@ hpd_registrations:
     - hpd_registrations/anyarray_uniq.sql
     - hpd_registrations/anyarray_remove_null.sql
     - hpd_registrations/first_last.sql
+    - hpd_registrations/contacts_cleanup.sql
     - hpd_registrations/corporate_owners.sql
     - hpd_registrations/business_addrs.sql
     - hpd_registrations/registrations_grouped_by_bbl.sql

--- a/src/nycdb/datasets.yml
+++ b/src/nycdb/datasets.yml
@@ -319,7 +319,7 @@ pluto_16v2:
       Version: text
       lng: numeric
       lat: numeric
-      
+
 dobjobs:
   files:
     -
@@ -432,7 +432,7 @@ dobjobs:
         bbl: char(10)
         id: 'serial PRIMARY KEY'
 
-      
+
 hpd_complaints:
   files:
     -
@@ -510,7 +510,7 @@ dob_complaints:
 
 hpd_violations:
   files:
-    - 
+    -
       url: https://data.cityofnewyork.us/api/views/wvxf-dwi5/rows.csv?accessType=DOWNLOAD
       dest: hpd_violations.csv
   sql:
@@ -526,7 +526,7 @@ hpd_violations:
       HouseNumber: text
       LowHouseNumber: text
       HighHouseNumber: text
-      StreetName: text 
+      StreetName: text
       StreetCode: text
       Postcode: char(5)
       Apartment: text
@@ -535,14 +535,14 @@ hpd_violations:
       Lot: integer
       Class: char(1)
       InspectionDate: date
-      ApprovedDate: date 
+      ApprovedDate: date
       OriginalCertifyByDate: date
       OriginalCorrectByDate: date
       NewCertifyByDate: date
       NewCorrectByDate: date
       CertifiedDate: date
       OrderNumber: text
-      NOVID: integer 
+      NOVID: integer
       NOVDescription: text
       NOVIssuedDate: date
       CurrentStatusID: smallint
@@ -578,7 +578,7 @@ hpd_registrations:
     - hpd_registrations/registrations_grouped_by_bbl_with_contacts.sql
     - hpd_registrations/functions.sql
     - hpd_registrations/index.sql
-    
+
   schema:
     -
       table_name: hpd_registrations
@@ -727,6 +727,41 @@ rentstab:
       numfloors: numeric
       unitsres: integer
       unitstotal: integer
+      yearbuilt: smallint
+      condono: smallint
+      lon: numeric
+      lat: numeric
+
+rentstab_summary:
+  files:
+    -
+      url: http://taxbills.nyc/changes-summary.csv
+      dest: changes-summary.csv
+  schema:
+    table_name: rentstab_summary
+    fields:
+      ucbbl: char(10)
+      unitstotal: integer
+      unitsstab2007: integer
+      unitsstab2016: integer
+      diff: integer
+      percentchange: numeric
+      j51: text
+      a421: text
+      scrie: text
+      drie: text
+      c420: text
+      cd: smallint
+      ct2010: text
+      cb2010: text
+      council: integer
+      zipcode: char(5)
+      address: text
+      ownername: text
+      numbldgs: smallint
+      numfloors: numeric
+      unitsres: integer
+      unitstotalpluto: integer
       yearbuilt: smallint
       condono: smallint
       lon: numeric
@@ -951,7 +986,7 @@ marshal_evictions_17:
   files:
     -
       url: https://s3.amazonaws.com/justfix-data/marshal_evictions_2017.csv
-      dest: marshal_evictions_17.csv 
+      dest: marshal_evictions_17.csv
   schema:
     table_name: marshal_evictions_17
     fields:

--- a/src/nycdb/sql/hpd_registrations/contacts_cleanup.sql
+++ b/src/nycdb/sql/hpd_registrations/contacts_cleanup.sql
@@ -1,0 +1,16 @@
+
+-- Null out values consisting purely of non-alphanumeric chars (\W), X's, and/or whitespace (\s)
+UPDATE hpd_contacts SET contactdescription = nullif(regexp_replace(contactdescription,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET corporationname = nullif(regexp_replace(corporationname,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET title = nullif(regexp_replace(title,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET firstname = nullif(regexp_replace(firstname,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET lastname = nullif(regexp_replace(lastname,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET businesshousenumber = nullif(regexp_replace(businesshousenumber,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET businessstreetname = nullif(regexp_replace(businessstreetname,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET businessapartment = nullif(regexp_replace(businessapartment,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET businesscity = nullif(regexp_replace(businesscity,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET businessstate = nullif(regexp_replace(businessstate,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET businesszip = nullif(regexp_replace(businesszip,'^(\W|X|\s)*$', ''),'');
+
+-- Null out middle initials that aren't letters, @, or & (which apparently people use...)
+UPDATE hpd_contacts SET middleinitial = nullif(regexp_replace(middleinitial,'^[^a-zA-Z@&]*$', ''),'');

--- a/src/nycdb/verify.py
+++ b/src/nycdb/verify.py
@@ -15,6 +15,7 @@ TABLES = {
     },
     'dof_sales': {'dof_sales': 75000},
     'rentstab': {'rentstab': 45000},
+    'rentstab_summary': {'rentstab_summary': 45000},
     'dob_complaints': {'dob_complaints': 1000000},
     'hpd_complaints': {
         'hpd_complaints': 1000000,
@@ -36,7 +37,7 @@ TABLES = {
         'acris_property_type_codes': 46,
         'acris_ucc_collateral_codes': 8
     },
-    'marshal_evictions_17': {'marshal_evictions_17': 17000} 
+    'marshal_evictions_17': {'marshal_evictions_17': 17000}
 }
 
 


### PR DESCRIPTION
This is a very simple addition that provides the option for the `rentstab-summary` dataset in addition to the more verbose crosstab one.