### PR TITLE
Adding rentstab-summary dataset to nyc-db

### DIFF
--- a/src/nycdb/dataset_transformations.py
+++ b/src/nycdb/dataset_transformations.py
@@ -52,6 +52,8 @@ def dobjobs(dataset):
 def rentstab(dataset):
     return to_csv(dataset.files[0].dest)
 
+def rentstab_summary(dataset):
+    return to_csv(dataset.files[0].dest)
 
 def acris(dataset, schema):
     dest_file = next(filter(lambda f: schema['table_name'] in f.dest, dataset.files))

--- a/src/nycdb/datasets.yml
+++ b/src/nycdb/datasets.yml
@@ -289,7 +289,7 @@ pluto_16v2:
       Version: text
       lng: numeric
       lat: numeric
-      
+
 dobjobs:
   files:
     -
@@ -402,7 +402,7 @@ dobjobs:
         bbl: char(10)
         id: 'serial PRIMARY KEY'
 
-      
+
 hpd_complaints:
   files:
     -
@@ -480,7 +480,7 @@ dob_complaints:
 
 hpd_violations:
   files:
-    - 
+    -
       url: https://data.cityofnewyork.us/api/views/wvxf-dwi5/rows.csv?accessType=DOWNLOAD
       dest: hpd_violations.csv
   sql:
@@ -496,7 +496,7 @@ hpd_violations:
       HouseNumber: text
       LowHouseNumber: text
       HighHouseNumber: text
-      StreetName: text 
+      StreetName: text
       StreetCode: text
       Postcode: char(5)
       Apartment: text
@@ -505,14 +505,14 @@ hpd_violations:
       Lot: integer
       Class: char(1)
       InspectionDate: date
-      ApprovedDate: date 
+      ApprovedDate: date
       OriginalCertifyByDate: date
       OriginalCorrectByDate: date
       NewCertifyByDate: date
       NewCorrectByDate: date
       CertifiedDate: date
       OrderNumber: text
-      NOVID: integer 
+      NOVID: integer
       NOVDescription: text
       NOVIssuedDate: date
       CurrentStatusID: smallint
@@ -548,7 +548,7 @@ hpd_registrations:
     - hpd_registrations/registrations_grouped_by_bbl_with_contacts.sql
     - hpd_registrations/functions.sql
     - hpd_registrations/index.sql
-    
+
   schema:
     -
       table_name: hpd_registrations
@@ -697,6 +697,41 @@ rentstab:
       numfloors: numeric
       unitsres: integer
       unitstotal: integer
+      yearbuilt: smallint
+      condono: smallint
+      lon: numeric
+      lat: numeric
+
+rentstab_summary:
+  files:
+    -
+      url: http://taxbills.nyc/changes-summary.csv
+      dest: changes-summary.csv
+  schema:
+    table_name: rentstab_summary
+    fields:
+      ucbbl: char(10)
+      unitstotal: integer
+      unitsstab2007: integer
+      unitsstab2016: integer
+      diff: integer
+      percentchange: numeric
+      j51: text
+      a421: text
+      scrie: text
+      drie: text
+      c420: text
+      cd: smallint
+      ct2010: text
+      cb2010: text
+      council: integer
+      zipcode: char(5)
+      address: text
+      ownername: text
+      numbldgs: smallint
+      numfloors: numeric
+      unitsres: integer
+      unitstotalpluto: integer
       yearbuilt: smallint
       condono: smallint
       lon: numeric
@@ -921,7 +956,7 @@ marshal_evictions_17:
   files:
     -
       url: https://s3.amazonaws.com/justfix-data/marshal_evictions_2017.csv
-      dest: marshal_evictions_17.csv 
+      dest: marshal_evictions_17.csv
   schema:
     table_name: marshal_evictions_17
     fields:

--- a/src/nycdb/verify.py
+++ b/src/nycdb/verify.py
@@ -14,6 +14,7 @@ TABLES = {
     },
     'dof_sales': {'dof_sales': 75000},
     'rentstab': {'rentstab': 45000},
+    'rentstab_summary': {'rentstab_summary': 45000},
     'dob_complaints': {'dob_complaints': 1000000},
     'hpd_complaints': {
         'hpd_complaints': 1000000,
@@ -35,7 +36,7 @@ TABLES = {
         'acris_property_type_codes': 46,
         'acris_ucc_collateral_codes': 8
     },
-    'marshal_evictions_17': {'marshal_evictions_17': 17000} 
+    'marshal_evictions_17': {'marshal_evictions_17': 17000}
 }
 
 


### PR DESCRIPTION
This is a very simple addition that provides the option for the `rentstab-summary` dataset in addition to the more verbose crosstab one.

Needed to update this PR to zone in on this code specifically.