### PR TITLE
Add a Docker Compose configuration and a "--dbshell" argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.6
+
+RUN apt-get update \
+  && apt-get install -y \
+    postgresql-client \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /src/*.deb
+
+COPY src/requirements.txt /nycdb/src/requirements.txt
+
+WORKDIR /nycdb/src
+
+RUN pip install -r requirements.txt --no-binary psycopg2
+
+COPY src/ /nycdb/src/
+
+RUN ls -al && pip install -e .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.5
 
 RUN apt-get update \
   && apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -56,6 +56,48 @@ As a convenience you can create the database in one go using this command:
 make nyc-db DB_HOST=localhost DB_DATABASE=nycdb DB_USER=databaseuser DB_PASSWORD=mypassword
 ```
 
+### Using Docker
+
+You can also use Docker to both use and develop nycdb. This can be useful because
+you only need to install Docker--you don't need to worry about installing the proper
+version of Python 3, Postgres, or any other tools.
+
+To proceed, first [install Docker][] and then run:
+
+```
+docker-compose up
+```
+
+After Docker downloads and builds some things, it will start a Postgres server on port
+7777 of your local machine, which you can connect to via a desktop client if you like.
+You can also press <kbd>CTRL</kbd>-<kbd>C</kbd> at any point to stop the server.
+
+In a separate terminal, you can run:
+
+```
+docker-compose run app bash
+```
+
+At this point you are inside a bash shell in a container that has everything already
+set up for you. The initial working directory will be `/nycdb`, which is mapped to
+the root of the project's repository. From here you can run `nycdb` to access the
+command-line tool.
+
+To develop on nycdb itself:
+
+* You can run `pytest` to run the test suite.
+* Any changes you make to the tool's source code will automatically be reflected
+  in future invocations to `nycdb` and/or the test suite.
+* If you don't have a desktop Postgres client, you can always run
+  `nycdb --dbshell` to interactively inspect the database with [`psql`][].
+
+You can leave the bash shell with `exit`.
+
+If you ever want to wipe the database, run `docker-compose down -v`.
+
+[install Docker]: https://www.docker.com/get-started
+[`psql`]: http://postgresguide.com/utilities/psql.html
+
 ### Setup the database and API on a cloud server
 
 See the folder `/ansible` for ansible playbooks to setup the database on a sever.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ make nyc-db DB_HOST=localhost DB_DATABASE=nycdb DB_USER=databaseuser DB_PASSWORD
 
 You can also use Docker to both use and develop nycdb. This can be useful because
 you only need to install Docker--you don't need to worry about installing the proper
-version of Python 3, Postgres, or any other tools.
+version of Python, Postgres, or any other tools.
 
 To proceed, first [install Docker][] and then run:
 
@@ -87,7 +87,7 @@ To develop on nycdb itself:
 
 * You can run `pytest` to run the test suite.
 * Any changes you make to the tool's source code will automatically be reflected
-  in future invocations to `nycdb` and/or the test suite.
+  in future invocations of `nycdb` and/or the test suite.
 * If you don't have a desktop Postgres client, you can always run
   `nycdb --dbshell` to interactively inspect the database with [`psql`][].
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '2'
+services:
+  app:
+    build: .
+    volumes:
+      - .:/nycdb
+    working_dir: /nycdb
+    environment:
+      - NYCDB_POSTGRES_HOST=db
+      - NYCDB_TEST_POSTGRES_HOST=db
+      - NYCDB_TEST_POSTGRES_DB=nycdb_test
+      - NYCDB_TEST_POSTGRES_USER=nycdb
+      - NYCDB_TEST_POSTGRES_PASSWORD=nycdb
+      - NYCDB_TEST_POSTGRES_PORT=5432
+    links:
+      - db
+  db:
+    image: postgres:10.5
+    environment:
+      - POSTGRES_PASSWORD=nycdb
+      - POSTGRES_USER=nycdb
+      - POSTGRES_DB=nycdb
+    ports:
+      - 7777:5432

--- a/src/nycdb/cli.py
+++ b/src/nycdb/cli.py
@@ -6,7 +6,11 @@ import sys
 from .dataset import Dataset, datasets
 
 
+POSTGRES_USER = os.environ.get('NYCDB_POSTGRES_USER', 'nycdb')
+POSTGRES_PASSWORD = os.environ.get('NYCDB_POSTGRES_PASSWORD', 'nycdb')
 POSTGRES_HOST = os.environ.get('NYCDB_POSTGRES_HOST', '127.0.0.1')
+POSTGRES_DB = os.environ.get('NYCDB_POSTGRES_DB', 'nycdb')
+POSTGRES_PORT = os.environ.get('NYCDB_POSTGRES_PORT', '5432')
 
 
 def parse_args():
@@ -21,16 +25,35 @@ def parse_args():
     parser.add_argument('--list-datasets', action='store_true', help='lists all datasets')
     parser.add_argument('--verify-all', action='store_true', help='verifies all datasets')
     # DB CONNECTION
-    parser.add_argument("-U", "--user", help="Postgres user. default: nycdb", default="nycdb")
-    parser.add_argument("-P", "--password", help="Postgres password. default: nycdb", default="nycdb")
+    parser.add_argument(
+        "-U",
+        "--user",
+        help="Postgres user. default: {}".format(POSTGRES_USER),
+        default=POSTGRES_USER
+    )
+    parser.add_argument(
+        "-P",
+        "--password",
+        help="Postgres password. default: {}".format(POSTGRES_PASSWORD),
+        default=POSTGRES_PASSWORD
+    )
     parser.add_argument(
         "-H",
         "--host",
         help="Postgres host: default: {}".format(POSTGRES_HOST),
         default=POSTGRES_HOST
     )
-    parser.add_argument("-D", "--database", help="postgres database: default: nycdb", default="nycdb")
-    parser.add_argument("--port", help="Postgres port: default: 5432", default="5432")
+    parser.add_argument(
+        "-D",
+        "--database",
+        help="postgres database: default: {}".format(POSTGRES_DB),
+        default=POSTGRES_DB
+    )
+    parser.add_argument(
+        "--port",
+        help="Postgres port: default: {}".format(POSTGRES_PORT),
+        default=POSTGRES_PORT
+    )
     # change location of data dir
     parser.add_argument("--root-dir", help="location of data directory", default="./data")
     # easily inspect the database from the command-line

--- a/src/tests/integration/test_nycdb.py
+++ b/src/tests/integration/test_nycdb.py
@@ -5,6 +5,8 @@ from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 import os
 from types import SimpleNamespace
 from decimal import Decimal
+import pytest
+
 import nycdb
 
 data_dir = os.path.join(os.path.dirname(__file__), 'data')
@@ -37,18 +39,35 @@ def create_db(dbname):
     conn.close()
 
 
-def connection(retries_left=5):
-    try:
-        return psycopg2.connect(**CONNECT_ARGS)
-    except psycopg2.OperationalError as e:
-        if 'database "{}" does not exist'.format(ARGS.database) in str(e):
-            create_db(ARGS.database)
-            return connection(retries_left - 1)
-        if retries_left:
-            # It's possible the database is still starting up.
-            time.sleep(2)
-            return connection(retries_left - 1)
-        raise e
+@pytest.fixture(scope="session")
+def db():
+    """
+    Attempt to connect to the database, retrying if necessary, and also
+    creating the database if it doesn't already exist.
+    """
+
+    retries_left = 5
+
+    while True:
+        try:
+            psycopg2.connect(**CONNECT_ARGS).close()
+            return
+        except psycopg2.OperationalError as e:
+            if 'database "{}" does not exist'.format(ARGS.database) in str(e):
+                create_db(ARGS.database)
+                retries_left -= 1
+            elif retries_left:
+                # It's possible the database is still starting up.
+                time.sleep(2)
+                retries_left -= 1
+            else:
+                raise e
+
+
+@pytest.fixture
+def conn(db):
+    with psycopg2.connect(**CONNECT_ARGS) as conn:
+        yield conn
 
 
 def drop_table(conn, table_name):
@@ -79,45 +98,37 @@ def table_columns(conn, table_name):
             return [x[0] for x in curs.fetchall()]
 
 
-def test_hpd_complaint_problems():
-    conn = connection()
+def test_hpd_complaint_problems(conn):
     drop_table(conn, 'hpd_complaint_problems')
     drop_table(conn, 'hpd_complaints')
     hpd_complaints = nycdb.Dataset('hpd_complaints', args=ARGS)
     hpd_complaints.db_import()
     assert row_count(conn, 'hpd_complaint_problems') == 9
-    conn.close()
 
-def test_hpd_complaints():
-    conn = connection()
+
+def test_hpd_complaints(conn):
     drop_table(conn, 'hpd_complaint_problems')
     drop_table(conn, 'hpd_complaints')
     hpd_complaints = nycdb.Dataset('hpd_complaints', args=ARGS)
     hpd_complaints.db_import()
     assert row_count(conn, 'hpd_complaints') == 100
-    conn.close()
 
 
-def test_dob_complaints():
-    conn = connection()
+def test_dob_complaints(conn):
     drop_table(conn, 'dob_complaints')
     dob_complaints = nycdb.Dataset('dob_complaints', args=ARGS)
     dob_complaints.db_import()
     assert row_count(conn, 'dob_complaints') == 100
-    conn.close()
 
 
-def test_pluto16v2():
-    conn = connection()
+def test_pluto16v2(conn):
     drop_table(conn, 'pluto_16v2')
     pluto = nycdb.Dataset('pluto_16v2', args=ARGS)
     pluto.db_import()
     assert row_count(conn, 'pluto_16v2') == 500
-    conn.close()
 
 
-def test_pluto_insert():
-    conn = connection()
+def test_pluto_insert(conn):
     with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
         curs.execute("select * from pluto_16v2 WHERE bbl = '1008820003'")
         rec = curs.fetchone()
@@ -128,79 +139,62 @@ def test_pluto_insert():
         assert round(rec['lat'], 5) == Decimal('40.74211')
 
 
-def test_pluto17v1():
-    conn = connection()
+def test_pluto17v1(conn):
     drop_table(conn, 'pluto_17v1')
     pluto = nycdb.Dataset('pluto_17v1', args=ARGS)
     pluto.db_import()
     assert row_count(conn, 'pluto_17v1') == 500
-    conn.close()
 
 
-def test_pluto18v1():
-    conn = connection()
+def test_pluto18v1(conn):
     drop_table(conn, 'pluto_18v1')
     pluto = nycdb.Dataset('pluto_18v1', args=ARGS)
     pluto.db_import()
     assert row_count(conn, 'pluto_18v1') == 50
-    conn.close()
 
 
-def test_hpd_violations():
-    conn = connection()
+def test_hpd_violations(conn):
     drop_table(conn, 'hpd_violations')
     hpd_violations = nycdb.Dataset('hpd_violations', args=ARGS)
     hpd_violations.db_import()
     assert row_count(conn, 'hpd_violations') == 100
-    conn.close()
 
 
-def test_hpd_violations_index():
-    conn = connection()
+def test_hpd_violations_index(conn):
     assert has_one_row(conn, "select 1 where to_regclass('public.hpd_violations_bbl_idx') is NOT NULL")
     assert has_one_row(conn, "select 1 where to_regclass('public.hpd_violations_violationid_idx') is NOT NULL")
     assert has_one_row(conn, "select 1 where to_regclass('public.hpd_violations_currentstatusid_idx') is NOT NULL")
-    conn.close()
 
 
-def test_hpd_registrations():
-    conn = connection()
+def test_hpd_registrations(conn):
     drop_table(conn, 'hpd_registrations')
     drop_table(conn, 'hpd_contacts')
     ds = nycdb.Dataset('hpd_registrations', args=ARGS)
     ds.db_import()
     assert row_count(conn, 'hpd_registrations') == 100
     assert row_count(conn, 'hpd_contacts') == 100
-    conn.close()
 
 
-def test_hpd_registrations_derived_tables():
-    conn = connection()
+def test_hpd_registrations_derived_tables(conn):
     assert row_count(conn, 'hpd_corporate_owners') > 10
     assert row_count(conn, 'hpd_registrations_grouped_by_bbl') > 10
     assert row_count(conn, 'hpd_business_addresses') > 10
     assert row_count(conn, 'hpd_registrations_grouped_by_bbl_with_contacts') > 10
-    conn.close()
 
 
-def test_hpd_registrations_rows():
-    conn = connection()
+def test_hpd_registrations_rows(conn):
     assert has_one_row(conn, "select * from hpd_registrations where bbl = '1017510116'")
-    conn.close()
 
 
-def test_dof_sales():
-    conn = connection()
+def test_dof_sales(conn):
     drop_table(conn, 'dof_sales')
     dof_sales = nycdb.Dataset('dof_sales', args=ARGS)
     dof_sales.db_import()
     assert row_count(conn, 'dof_sales') == 70
     assert has_one_row(conn, "select 1 where to_regclass('public.dof_sales_bbl_idx') is NOT NULL")
-    conn.close()
 
 
-def test_dobjobs():
-    conn = connection()
+def test_dobjobs(conn):
     drop_table(conn, 'dobjobs')
     dobjobs = nycdb.Dataset('dobjobs', args=ARGS)
     dobjobs.db_import()
@@ -215,21 +209,17 @@ def test_dobjobs():
     columns = table_columns(conn, 'dobjobs')
     assert 'ownername_tsvector' in columns
     assert 'applicantname_tsvector' in columns
-    conn.close()
 
 
-def test_rentstab():
-    conn = connection()
+def test_rentstab(conn):
     drop_table(conn, 'rentstab')
     rentstab = nycdb.Dataset('rentstab', args=ARGS)
     rentstab.db_import()
     assert row_count(conn, 'rentstab') == 100
     assert has_one_row(conn, "select 1 where to_regclass('public.rentstab_ucbbl_idx') is NOT NULL")
-    conn.close()
 
 
-def test_acris():
-    conn = connection()
+def test_acris(conn):
     drop_table(conn, 'real_property_legals')
     drop_table(conn, 'real_property_master')
     drop_table(conn, 'real_property_parties')
@@ -261,11 +251,9 @@ def test_acris():
     assert row_count(conn, 'acris_property_type_codes') == 46
     assert row_count(conn, 'acris_ucc_collateral_codes') == 8
     assert has_one_row(conn, "select * from real_property_legals where bbl = '4131600009'")
-    conn.close()
 
 
-def test_marshal_evictions_17():
-    conn = connection()
+def test_marshal_evictions_17(conn):
     drop_table(conn, 'marshal_evictions_17')
     evictions = nycdb.Dataset('marshal_evictions_17', args=ARGS)
     evictions.db_import()
@@ -278,8 +266,7 @@ def test_marshal_evictions_17():
         assert rec['lat'] == Decimal('40.71081')
 
 
-def test_oath_hearings():
-    conn = connection()
+def test_oath_hearings(conn):
     drop_table(conn, 'oath_hearings')
     oath_hearings = nycdb.Dataset('oath_hearings', args=ARGS)
     oath_hearings.db_import()
@@ -291,8 +278,7 @@ def test_oath_hearings():
         assert rec['totalviolationamount'] == Decimal('40000.00')
 
 
-def test_dob_violations():
-    conn = connection()
+def test_dob_violations(conn):
     drop_table(conn, 'dob_violations')
     dob_violations = nycdb.Dataset('dob_violations', args=ARGS)
     dob_violations.db_import()

--- a/src/tests/integration/test_nycdb.py
+++ b/src/tests/integration/test_nycdb.py
@@ -313,7 +313,6 @@ def run_cli(args, input):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         universal_newlines=True,
-        encoding='ascii'
     )
 
     try:


### PR DESCRIPTION
I'm not sure if you'll think this is a good idea or not, so I'm floating this as a proof-of-concept for now to see what folks think of it.

It does the following:

* Adds a Docker Compose configuration to make getting started with nycdb and/or nycdb development easier.  For example, running `docker-compose run app pytest` will run all the unit and integration tests, while `docker-compose up` will start a postgres server on port 7777, and `docker-compose run app nycdb <args>` will run the CLI.

    This is particularly nice for folks on Windows, where dealing with Postgres, psycopg2, and various Unix tools like `make` can be a huge pain.

    It _might_ be useful for less technical users who don't already have Python 3.x and Postgres on their system, but I'm not sure.

    It would also be useful for developers who might have conflicting versions of Python or Postgres already on their host system.

* Adds a `NYCDB_POSTGRES_HOST` environment variable that can be used to configure the CLI's postgres host without having to constantly pass-in `-H <hostname>` all the time. Ideally I think we should support such environment variables, or perhaps a single `NYCDB_DATABASE_URI` one, to make it easy to interact with the database if one's configuration doesn't happen to conform to the CLI's defaults, but I've only added `NYCDB_POSTGRES_HOST` for now to get the Docker Compose setup functional.

* Adds a `nycdb --dbshell` argument that is basically like [Django's `dbshell`](https://docs.djangoproject.com/en/2.1/ref/django-admin/#dbshell), for quick-and-easy access to an interactive `psql` that's automatically connected to the database using whatever credentials nycdb uses.

* Adds a bunch of `NYCDB_TEST_*` environment variables so the integration tests can work with the Docker Compose setup.  The test suite also attempts to create the test database if it doesn't already exist.  There's lots of other ways to work around this problem, though.

## Limitations

* The Docker Compose setup does _not_ currently support signing and uploading of nycdb to PyPI.  I think it might be neat if it did, though, as that would make it easier for anyone who needs to re-publish it to do so with a consistent build environment.

* This doesn't currently have any documentation.  I would like to add some to the README but I wanted to hold off on it for now because I'm not sure if folks even think adding Docker Compose support is a good idea yet.

Anyhow, let me know if you think this would be useful to merge with master. If so, I will add docs at the very least, and no worries if not!
