### PR TITLE
Remove tox.ini

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,5 +8,4 @@ doc
 src/.cache
 src/*.egg-info
 src/tests
-src/*.tox
 src/venv

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -25,7 +25,6 @@ pip-log.txt
 # Unit test / coverage reports
 .cache
 .coverage
-.tox
 nosetests.xml
 
 # Translations

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -1,6 +1,0 @@
-[tox]
-envlist=py34,py35
-
-[testenv]
-commands=py.test nycdb
-deps=pytest


### PR DESCRIPTION
Fixes #39.

Note that I also removed some references to `.tox` and `*.tox` from `.gitignore`/`.dockerignore`. I assumed those are tox-related, but I'm not actually sure, so let me know if I'm mistaken!