### PR TITLE
Add basic progress bars for downloading and database loading

### DIFF
--- a/src/nycdb/dataset.py
+++ b/src/nycdb/dataset.py
@@ -4,6 +4,7 @@ import itertools
 import os
 import subprocess
 from functools import lru_cache
+from tqdm import tqdm
 
 from . import verify
 from . import dataset_transformations
@@ -91,12 +92,15 @@ class Dataset:
     def import_schema(self, schema):
         rows = self.transform(schema)
 
+        pbar = tqdm(unit='rows')
         while True:
             batch = list(itertools.islice(rows, 0, BATCH_SIZE))
             if len(batch) == 0:
                 break
             else:
+                pbar.update(len(batch))
                 self.db.insert_rows(batch, table_name=schema['table_name'])
+        pbar.close()
 
     def create_schema(self):
         create_table = lambda name, fields: self.db.sql(sql.create_table(name, fields))

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,5 +3,6 @@ PyYAML
 requests
 psycopg2
 pyproj
+tqdm
 xlrd
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -38,7 +38,8 @@ setuptools.setup(
         'requests>=2.18',
         'xlrd>=1.1.0',
         'pyproj>=1.9.5',
-        'psycopg2>=2.7'
+        'psycopg2>=2.7',
+        'tqdm>=4.28.1'
     ],
 
     classifiers=[

--- a/src/tests/unit/test_file.py
+++ b/src/tests/unit/test_file.py
@@ -1,4 +1,5 @@
 import nycdb
+from nycdb.file import safe_int
 
 import time
 import http.server
@@ -42,3 +43,10 @@ def test_download_file(tmpdir):
     assert dest.read() == 'i am a file'
     # This should return True and not attempt to download the file again:
     assert nycdb.file.download_file('http://localhost:6789/www/file.txt', dest.strpath)
+
+
+def test_safe_int():
+    assert safe_int(None) is None
+    assert safe_int('') is None
+    assert safe_int('blaah') is None
+    assert safe_int('15') == 15


### PR DESCRIPTION
This fixes #25 by adding progress bars via [`tqdm`](https://github.com/tqdm/tqdm).

The bars for downloading tend to be informative because they use the HTTP request's `Content-Length` header to provide total progress details and predict the time remaining:

![file download progress bar](https://user-images.githubusercontent.com/124687/48946747-ad368200-eefc-11e8-9cf3-53d5592005f4.png)

Some downloads don't include the length header, however, so information will be more bare-bones.

The information for database loading is extremely simplistic right now because, as far as I can tell, the insertion pipeline uses generators that don't provide any information about how many total rows are being processed:

![database insertion progress bar](https://user-images.githubusercontent.com/124687/48946746-ad368200-eefc-11e8-809b-5b47e5fabea6.png)

That said, it's still much better than no progress information at all (when I first ran nycdb I wasn't sure if the db insertion process had hung or not).

There's a number of ways we can improve this but I figured this is a good start, and we could talk about potential ways to improve the db insertion because there's a number of different approaches we could take.
