### PR TITLE
Add references to 2017 rentstab data

### DIFF
--- a/src/nycdb/datasets.yml
+++ b/src/nycdb/datasets.yml
@@ -717,6 +717,10 @@ rentstab:
       est2016: boolean
       dhcr2016: boolean
       abat2016: text[]
+      uc2017: integer
+      est2017: boolean
+      dhcr2017: boolean
+      abat2017: text[]
       cd: smallint
       ct2010: text
       cb2010: text
@@ -744,7 +748,7 @@ rentstab_summary:
       ucbbl: char(10)
       unitstotal: integer
       unitsstab2007: integer
-      unitsstab2016: integer
+      unitsstab2017: integer
       diff: integer
       percentchange: numeric
       j51: text
@@ -1032,13 +1036,13 @@ oath_hearings:
       ViolationLocationHouse: text
       ViolationLocationStreetName: text
       ViolationLocationFloor: text
-      ViolationLocationCity: text 
+      ViolationLocationCity: text
       ViolationLocationZipCode: char(5)
       ViolationLocationStateName: text
       RespondentAddressBorough: text
       RespondentAddressHouse: text
       RespondentAddressStreetName: text
-      RespondentAddressCity: text 
+      RespondentAddressCity: text
       RespondentAddressZipCode: char(5)
       RespondentAddressStateName: text
       HearingStatus: text
@@ -1056,17 +1060,17 @@ oath_hearings:
       PaidAmount: numeric
       AdditionalPenaltiesorLateFees: numeric
       ComplianceStatus: text
-      ViolationDescription: text 
+      ViolationDescription: text
       Charge1Code: text
       Charge1CodeSection: text
       Charge1CodeDescription: text
       Charge1InfractionAmount: numeric
       Charge2Code: text
-      Charge2CodeSection: text 
+      Charge2CodeSection: text
       Charge2CodeDescription: text
       Charge2InfractionAmount: numeric
       Charge3Code: text
-      Charge3CodeSection: text 
+      Charge3CodeSection: text
       Charge3CodeDescription: text
       Charge3InfractionAmount: numeric
       Charge4Code: text


### PR DESCRIPTION
Adding references to the 207 rentstab data. I've tested this with `rentstab-summary` but it might be good to take a second look at `joined.csv`. Also can/should update with refreshed test data!