### PR TITLE
Install test data.

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -1,4 +1,16 @@
+import os
 import setuptools
+
+MY_DIR = os.path.abspath(os.path.dirname(__file__))
+
+TEST_DATA_RELATIVE_DIR = os.path.join('tests', 'integration', 'data')
+
+TEST_DATA_DIR = os.path.join(MY_DIR, TEST_DATA_RELATIVE_DIR)
+
+TEST_DATA_FILES = [
+    os.path.join(TEST_DATA_RELATIVE_DIR, filename)
+    for filename in os.listdir(TEST_DATA_DIR)
+]
 
 setuptools.setup(
     name="nycdb",
@@ -28,6 +40,10 @@ setuptools.setup(
             'sql/**/*.sql'
         ]
     },
+
+    data_files=[
+        ('nycdb_test_data', TEST_DATA_FILES),
+    ],
 
     include_package_data=True,
 


### PR DESCRIPTION
I'm not sure if I'm doing things the best way to fix #55 here.

Ideally I think the test data would go in a subdirectory of the `nycdb` package directory itself.  However, because the integration test data isn't already in that package directory, it can't (afaik) be specified as part of `package_data` in `setup.py`.  So instead, I used [`data_files`](https://docs.python.org/2/distutils/setupscript.html#installing-additional-files) to specify the data, which actually means it's going to be installed relative to `sys.prefix`, so e.g. in `/usr/local/nycdb_test_data`, which feels kind of weird.

Another option is to just move the integration test data into the `nycdb` package directory in this repository, and have the integration tests look for it there.  Then we could just add the data directory to `package_data`.

Any preference @aepyornis, or is there some other solution I'm overlooking?
