### PR TITLE
Attempt to fix pyproj-related Travis CI breakage and PyYAML warning

### DIFF
--- a/src/nycdb/utility.py
+++ b/src/nycdb/utility.py
@@ -6,7 +6,7 @@ from pathlib import Path
 def read_yml(file):
     """Reads a yaml file and outputs a Dictionary"""
     with open(file, 'r') as yaml_file:
-        return yaml.load(yaml_file)
+        return yaml.load(yaml_file, Loader=yaml.FullLoader)
 
 
 def mkdir(file_path):

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,7 +2,7 @@ pytest
 PyYAML
 requests
 psycopg2
-pyproj
+pyproj==1.9.6
 tqdm
 xlrd
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
         'PyYAML>=3',
         'requests>=2.18',
         'xlrd>=1.1.0',
-        'pyproj>=1.9.5',
+        'pyproj>=1.9.5,<2',
         'psycopg2>=2.7',
         'tqdm>=4.28.1'
     ],


### PR DESCRIPTION
This is an exploration into attempting to fix the [Travis CI breakage]().  It seems like the following test is breaking:

```
    def test_pluto_insert(conn):
        with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
            curs.execute("select * from pluto_16v2 WHERE bbl = '1008820003'")
            rec = curs.fetchone()
            assert rec is not None
            assert rec['address'] == '369 PARK AVENUE SOUTH'
            assert rec['lotarea'] == 8032
            assert round(rec['lng'], 5) == Decimal('-73.98434')
>           assert round(rec['lat'], 5) == Decimal('40.74211')
E           AssertionError: assert Decimal('40.74212') == Decimal('40.74211')
E            +  where Decimal('40.74212') = round(Decimal('40.74212184463369368359053623862564563751220703125'), 5)
E            +  and   Decimal('40.74211') = Decimal('40.74211')
```

I think this is happening because of something related to pyproj.  The tests actually run fine on my system, but once I upgraded to the latest version of pyproj, they seemed to not only reproduce this error but also take an _incredibly_ long time to run, for some reason.  Looking at [pyproj's release history](https://github.com/pyproj4/pyproj/releases) (and [changelog](https://pyproj4.github.io/pyproj/html/history.html)) it appears the project released version 2 in early March of this year, and has been evolving rapidly since then, so I'm not sure what's going on.

My very un-ideal fix is simply to pin pyproj to 1.9.6 (the latest in the 1.x series).  But there is probably a better way to go about fixing things, I'm really just submitting this PR to see if Travis CI likes it.

Additionally, I fixed a warning regarding [PyYAML yaml.load(input) Deprecation](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation) that seems to be logged by newer versions of PyYAML.
