### PR TITLE
Add more indexes to various tables

### DIFF
--- a/src/nycdb/datasets/dob_complaints.yml
+++ b/src/nycdb/datasets/dob_complaints.yml
@@ -21,3 +21,5 @@ schema:
     dispositioncode: text
     inspectiondate: date
     dobrundate: date
+sql:
+  - dob_complaints.sql

--- a/src/nycdb/datasets/hpd_complaints.yml
+++ b/src/nycdb/datasets/hpd_complaints.yml
@@ -47,3 +47,5 @@ schema:
       Status: text
       StatusDate: date
       StatusDescription: text
+sql:
+  - hpd_complaints.sql

--- a/src/nycdb/sql/dob_complaints.sql
+++ b/src/nycdb/sql/dob_complaints.sql
@@ -1,0 +1,1 @@
+CREATE INDEX dob_complaints_bin_idx on dob_complaints (bin);

--- a/src/nycdb/sql/dob_violations.sql
+++ b/src/nycdb/sql/dob_violations.sql
@@ -2,3 +2,4 @@ CREATE INDEX dob_violations_bbl_idx on dob_violations (bbl);
 CREATE UNIQUE INDEX dob_violations_isndobbisviol_idx on dob_violations (isndobbisviol);
 CREATE INDEX dob_violations_violationtypecode on dob_violations (violationtypecode);
 CREATE INDEX dob_violations_ecb_number_idx on dob_violations (ecbnumber);
+CREATE INDEX dob_violations_bin_idx on dob_violations (bin);

--- a/src/nycdb/sql/dobjobs/index.sql
+++ b/src/nycdb/sql/dobjobs/index.sql
@@ -1,5 +1,7 @@
 -- bbl
 create index on dobjobs (bbl);
+-- bin
+create index on dobjobs (bin);
 -- Latest Action Date 
 create index on dobjobs (LatestActionDate DESC NULLS LAST);
 create index on dobjobs (LatestActionDate DESC);	

--- a/src/nycdb/sql/hpd_complaints.sql
+++ b/src/nycdb/sql/hpd_complaints.sql
@@ -1,0 +1,3 @@
+CREATE INDEX hpd_complaints_buildingid_idx on hpd_complaints (buildingid);
+CREATE INDEX hpd_complaints_complaintid_idx on hpd_complaints (complaintid);
+CREATE INDEX hpd_complaint_problems_complaintid_idx on hpd_complaint_problems (complaintid);

--- a/src/nycdb/sql/hpd_registrations/index.sql
+++ b/src/nycdb/sql/hpd_registrations/index.sql
@@ -3,3 +3,4 @@ create index on hpd_contacts(type);
 create index on hpd_contacts(registrationid);
 create index on hpd_contacts(registrationid) WHERE type = 'CorporateOwner';
 create index on hpd_registrations(registrationid);
+create index on hpd_registrations(buildingid);

--- a/src/nycdb/sql/hpd_violations.sql
+++ b/src/nycdb/sql/hpd_violations.sql
@@ -1,3 +1,4 @@
 CREATE INDEX hpd_violations_bbl_idx on hpd_violations (bbl);
 CREATE UNIQUE INDEX hpd_violations_violationid_idx on hpd_violations (violationid);
 CREATE INDEX hpd_violations_currentstatusid_idx on hpd_violations (currentstatusid);
+CREATE INDEX hpd_violations_bin_idx on hpd_violations (bin);


### PR DESCRIPTION
At JustFix we are [moving towards](https://github.com/JustFixNYC/tenants2/pull/590) associating users with BINs rather than just BBLs, which makes a lot of our data analysis more [accurate](https://github.com/JustFixNYC/tenants2/pull/593).

To assist in this, and to make it easier for others to do the same, this PR adds a bunch of indexes to various tables in NYCDB:

* DOB complaints, DOB violations, DOB jobs, and HPD violations are all indexed by BIN.

* HPD complaints and HPD complaint problems are now indexed by complaint ID, so it's more efficient to join them.

* HPD complaints and HPD registrations are now indexed by HPD building ID (a unique identifier assigned to each building by HPD, distinct from BIN and BBL).  This ultimately makes it efficient to join them, which makes it efficient to correlate an HPD complaint with a BIN.
